### PR TITLE
Fix circular dependency in security config

### DIFF
--- a/Todo_tp_back/src/main/java/org/example/todo_tp_back/config/AppConfig.java
+++ b/Todo_tp_back/src/main/java/org/example/todo_tp_back/config/AppConfig.java
@@ -1,0 +1,15 @@
+package org.example.todo_tp_back.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class AppConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/Todo_tp_back/src/main/java/org/example/todo_tp_back/config/SecurityConfig.java
+++ b/Todo_tp_back/src/main/java/org/example/todo_tp_back/config/SecurityConfig.java
@@ -15,7 +15,6 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -26,6 +25,7 @@ public class SecurityConfig {
 
     private final UserService userService;
     private final JwtService jwtService;
+    private final PasswordEncoder passwordEncoder;
 
     @Bean
     public UserDetailsService userDetailsService() {
@@ -40,16 +40,12 @@ public class SecurityConfig {
                 .orElseThrow(() -> new UsernameNotFoundException("User not found"));
     }
 
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
 
     @Bean
     public AuthenticationProvider authenticationProvider() {
         DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
         provider.setUserDetailsService(userDetailsService());
-        provider.setPasswordEncoder(passwordEncoder());
+        provider.setPasswordEncoder(passwordEncoder);
         return provider;
     }
 


### PR DESCRIPTION
## Summary
- create `AppConfig` with `PasswordEncoder` bean
- inject `PasswordEncoder` in `SecurityConfig` and remove its bean method

## Testing
- `./mvnw -q test` *(fails: wget can't download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684ae08c92848328951a8a2f704dbc47