### PR TITLE
Front-end integrated with backend API

### DIFF
--- a/Todo_tp/src/AuthContext.tsx
+++ b/Todo_tp/src/AuthContext.tsx
@@ -1,0 +1,38 @@
+import React, { createContext, useContext, useState } from 'react';
+import * as api from './api';
+
+interface AuthContextProps {
+  token: string | null;
+  login: (username: string, password: string) => Promise<void>;
+  signup: (username: string, password: string, role: string) => Promise<void>;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextProps>(null!);
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [token, setToken] = useState<string | null>(() => localStorage.getItem('token'));
+
+  const login = async (username: string, password: string) => {
+    const t = await api.login(username, password);
+    localStorage.setItem('token', t);
+    setToken(t);
+  };
+
+  const signup = async (username: string, password: string, role: string) => {
+    await api.signup(username, password, role);
+  };
+
+  const logout = () => {
+    localStorage.removeItem('token');
+    setToken(null);
+  };
+
+  return (
+    <AuthContext.Provider value={{ token, login, signup, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => useContext(AuthContext);

--- a/Todo_tp/src/api.ts
+++ b/Todo_tp/src/api.ts
@@ -1,0 +1,69 @@
+const API_URL = 'http://localhost:8080/api';
+
+export interface Todo {
+  id: number;
+  title: string;
+  description: string;
+  completed: boolean;
+}
+
+function authHeader(token?: string): Record<string, string> {
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+export async function login(username: string, password: string) {
+  const res = await fetch(`${API_URL}/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password })
+  });
+  if (!res.ok) throw new Error('Login failed');
+  const data = await res.json();
+  return data.token as string;
+}
+
+export async function signup(username: string, password: string, role: string) {
+  const res = await fetch(`${API_URL}/auth/signup`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password, role })
+  });
+  if (!res.ok) throw new Error('Signup failed');
+  return res.json();
+}
+
+export async function getTodos(token: string) {
+  const res = await fetch(`${API_URL}/todos`, {
+    headers: authHeader(token)
+  });
+  if (!res.ok) throw new Error('Failed to fetch todos');
+  return res.json() as Promise<Todo[]>;
+}
+
+export async function createTodo(todo: Omit<Todo, 'id'>, token: string) {
+  const res = await fetch(`${API_URL}/todos`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...authHeader(token) },
+    body: JSON.stringify(todo)
+  });
+  if (!res.ok) throw new Error('Failed to create todo');
+  return res.json() as Promise<Todo>;
+}
+
+export async function updateTodo(id: number, todo: Todo, token: string) {
+  const res = await fetch(`${API_URL}/todos/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json', ...authHeader(token) },
+    body: JSON.stringify(todo)
+  });
+  if (!res.ok) throw new Error('Failed to update todo');
+  return res.json() as Promise<Todo>;
+}
+
+export async function deleteTodo(id: number, token: string) {
+  const res = await fetch(`${API_URL}/todos/${id}`, {
+    method: 'DELETE',
+    headers: authHeader(token)
+  });
+  if (!res.ok) throw new Error('Failed to delete todo');
+}

--- a/Todo_tp/src/components/Navbar.tsx
+++ b/Todo_tp/src/components/Navbar.tsx
@@ -4,6 +4,7 @@ import Modal from './Modal';
 import LoginForm from '../ui/LoginForm';
 import SignUpForm from '../ui/SignUpForm';
 import { LoginIcon, UserIcon } from './Icons';
+import { useAuth } from '../AuthContext';
 
 interface NavbarProps {
   title: string;
@@ -11,8 +12,9 @@ interface NavbarProps {
 
 const Navbar: React.FC<NavbarProps> = ({ title }) => {
 
-    const [isModalLoginOpen, setIsModalLoginOpen] = useState<boolean>(false);
-    const [isModalSignupOpen, setIsModalSignupOpen] = useState<boolean>(false);
+  const { token, logout } = useAuth();
+  const [isModalLoginOpen, setIsModalLoginOpen] = useState<boolean>(false);
+  const [isModalSignupOpen, setIsModalSignupOpen] = useState<boolean>(false);
 
   return (
     <>
@@ -23,14 +25,20 @@ const Navbar: React.FC<NavbarProps> = ({ title }) => {
                 <span>{title}</span>
             </div>
             <div className="flex items-center space-x-4 py-4 justify-center">
-                <Button onClick={() => setIsModalLoginOpen(true)} className="flex items-center space-x-2">
-                    <LoginIcon className="w-4 h-4" />
-                    <span>Login</span>
-                </Button>
-                <Button onClick={() => setIsModalSignupOpen(true)} className="flex items-center space-x-2">
-                    <UserIcon className="w-4 h-4" />
-                    <span>Sign Up</span>
-                </Button>
+                {token ? (
+                  <Button onClick={logout}>Logout</Button>
+                ) : (
+                  <>
+                    <Button onClick={() => setIsModalLoginOpen(true)} className="flex items-center space-x-2">
+                      <LoginIcon className="w-4 h-4" />
+                      <span>Login</span>
+                    </Button>
+                    <Button onClick={() => setIsModalSignupOpen(true)} className="flex items-center space-x-2">
+                      <UserIcon className="w-4 h-4" />
+                      <span>Sign Up</span>
+                    </Button>
+                  </>
+                )}
             </div>
             </div>
         </div>

--- a/Todo_tp/src/main.tsx
+++ b/Todo_tp/src/main.tsx
@@ -3,11 +3,14 @@ import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './App.tsx'
+import { AuthProvider } from './AuthContext'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <BrowserRouter>
-      <App />
+      <AuthProvider>
+        <App />
+      </AuthProvider>
     </BrowserRouter>
   </StrictMode>,
 )

--- a/Todo_tp/src/pages/HomePage.tsx
+++ b/Todo_tp/src/pages/HomePage.tsx
@@ -15,9 +15,10 @@ type Props = {
   todos: Todo[];
   onDelete: (id: number) => void;
   onToggle: (id: number) => void;
+  onCreate: (todo: Omit<Todo, 'id'>) => void;
 };
 
-const TodoList: React.FC<Props> = ({ todos, onDelete, onToggle }) => {
+const TodoList: React.FC<Props> = ({ todos, onDelete, onToggle, onCreate }) => {
 
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
 
@@ -74,7 +75,7 @@ const TodoList: React.FC<Props> = ({ todos, onDelete, onToggle }) => {
         </table>
       </div>
       <Modal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} hideHeader>
-        <TodoForm />
+        <TodoForm onCreate={(t) => { onCreate(t); setIsModalOpen(false); }} />
       </Modal>
     </>
   );

--- a/Todo_tp/src/ui/LoginForm.tsx
+++ b/Todo_tp/src/ui/LoginForm.tsx
@@ -1,12 +1,26 @@
-import React from "react";
-import Button from "../components/Button";
-import { UserIcon, LockIcon } from "../components/Icons";
+import React, { useState } from 'react';
+import Button from '../components/Button';
+import { UserIcon, LockIcon } from '../components/Icons';
+import { useAuth } from '../AuthContext';
 
 const LoginForm: React.FC = () => {
+  const { login } = useAuth();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await login(username, password);
+    } catch {
+      alert('Login failed');
+    }
+  };
+
   return (
     <div className="flex flex-col items-center justify-center pt-5 bg-gray-100">
       <h1 className="text-2xl font-bold mb-6">Login</h1>
-      <form className="w-lg bg-white p-8 rounded shadow-md space-y-4">
+      <form onSubmit={handleSubmit} className="w-lg bg-white p-8 rounded shadow-md space-y-4">
         <div>
           <label htmlFor="username" className="block text-sm font-medium text-gray-700">Email</label>
           <div className="relative mt-1">
@@ -18,6 +32,8 @@ const LoginForm: React.FC = () => {
               id="username"
               name="username"
               required
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
               className="pl-10 block w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-blue-500 focus:border-blue-500"
             />
           </div>
@@ -33,6 +49,8 @@ const LoginForm: React.FC = () => {
               id="password"
               name="password"
               required
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
               className="pl-10 block w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-blue-500 focus:border-blue-500"
             />
           </div>

--- a/Todo_tp/src/ui/SignUpForm.tsx
+++ b/Todo_tp/src/ui/SignUpForm.tsx
@@ -1,23 +1,29 @@
 // components/SignUpForm.tsx
-import React, { useState } from "react";
+import React, { useState } from 'react';
 import Button from '../components/Button';
 import { UserIcon, LockIcon } from '../components/Icons';
+import { useAuth } from '../AuthContext';
 
 const SignUpForm: React.FC = () => {
-  const [username, setUsername] = useState("");
-  const [password, setPassword] = useState("");
-  const [confirmPassword, setConfirmPassword] = useState("");
-  const [role, setRole] = useState("USER");
+  const { signup } = useAuth();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [role, setRole] = useState('USER');
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (password !== confirmPassword) {
-      alert("Les mots de passe ne correspondent pas.");
+      alert('Les mots de passe ne correspondent pas.');
       return;
     }
 
-    // Appel API d’inscription ici
-    console.log({ username, password, role });
+    try {
+      await signup(username, password, role);
+      alert('Compte créé');
+    } catch {
+      alert("Erreur lors de l'inscription");
+    }
   };
 
   return (

--- a/Todo_tp/src/ui/TodoForm.tsx
+++ b/Todo_tp/src/ui/TodoForm.tsx
@@ -1,31 +1,53 @@
-import React, { useState } from "react";
-import Button from "../components/Button";
-import { PlusIcon } from "../components/Icons";
+import React, { useState } from 'react';
+import Button from '../components/Button';
+import { PlusIcon } from '../components/Icons';
+import type { Todo } from '../api';
 
-const TodoForm: React.FC = () => {
-  const [status, setStatus] = useState("not_completed");
+interface Props {
+  onCreate: (todo: Omit<Todo, 'id'>) => void;
+}
+const TodoForm: React.FC<Props> = ({ onCreate }) => {
+  const [status, setStatus] = useState('not_completed');
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onCreate({
+      title,
+      description,
+      completed: status === 'completed'
+    });
+    setTitle('');
+    setDescription('');
+    setStatus('not_completed');
+  };
 
   return (
     <div className="flex flex-col items-center justify-center pt-5 bg-gray-100">
       <h1 className="text-2xl font-bold mb-6">New To-Do</h1>
-      <form className="w-lg bg-white p-8 rounded shadow-md">
+      <form onSubmit={handleSubmit} className="w-lg bg-white p-8 rounded shadow-md">
         <div className="mb-4">
           <label htmlFor="title" className="block text-sm font-medium text-gray-700">Titre</label>
-          <input
-            type="text"
-            name="title"
-            required
-            className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-blue-500 focus:border-blue-500"
-          />
+            <input
+              type="text"
+              name="title"
+              required
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+            />
         </div>
 
         <div className="mb-4">
           <label htmlFor="description" className="block text-sm font-medium text-gray-700">Description</label>
-          <textarea
-            name="description"
-            required
-            className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-blue-500 focus:border-blue-500"
-          />
+            <textarea
+              name="description"
+              required
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+            />
         </div>
 
         <div className="mb-6">


### PR DESCRIPTION
## Summary
- create API wrapper and auth context for React app
- implement signup/login/todo actions connected to backend
- add todo creation modal and wire to backend
- add logout button depending on auth state

## Testing
- `npm run build`
- `npm run lint`
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ae89a25208328809711d0a0a30de0